### PR TITLE
feat(registry): coexist registry with Storybook on one Vercel deploy

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -15,6 +15,6 @@ const config: StorybookConfig = {
     options: {},
   },
 
-  staticDirs: ["../assets"]
+  staticDirs: ["../assets", "../public"]
 }
 export default config

--- a/README.md
+++ b/README.md
@@ -91,16 +91,25 @@ npm run registry:generate   # regenerate registry.json from src/components
 npm run registry:build      # regenerate + shadcn build → public/r/*.json
 ```
 
-After deployment (Vercel, GitHub Pages, etc.), consumers install with:
+Hosting rides along with the Storybook deployment on Vercel: `public/r/` is
+copied into Storybook's `storybook-static/` output dir via
+`.storybook/main.ts`'s `staticDirs`, so the same domain serves both the
+Storybook UI and the registry endpoints.
+
+- Storybook UI:          <https://gymnopedies.shoota.work/>
+- Registry preset:       <https://gymnopedies.shoota.work/r/gymnopedies.json>
+- Individual items:      <https://gymnopedies.shoota.work/r/article.json> etc.
+
+Consumers install with:
 
 ```bash
 # Install the whole gymnopedies preset (theme + all components)
-npx shadcn@latest add https://<your-host>/r/gymnopedies.json
+npx shadcn@latest add https://gymnopedies.shoota.work/r/gymnopedies.json
 
 # Or pick individual items
-npx shadcn@latest add https://<your-host>/r/theme.json
-npx shadcn@latest add https://<your-host>/r/hero.json
-npx shadcn@latest add https://<your-host>/r/card.json
+npx shadcn@latest add https://gymnopedies.shoota.work/r/theme.json
+npx shadcn@latest add https://gymnopedies.shoota.work/r/hero.json
+npx shadcn@latest add https://gymnopedies.shoota.work/r/card.json
 ```
 
 Consumers need Tailwind CSS v4 and the `@/*` path alias configured in their project.

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "npm run build-storybook",
+  "buildCommand": "npm run registry:build && npm run build-storybook",
   "devCommand": "npm run storybook",
   "installCommand": "npm ci --include=optional",
   "framework": null,


### PR DESCRIPTION
## Summary

Lets the existing \`shootas-projects/gymnopedies\` Vercel project serve both
the Storybook UI and the shadcn registry JSON from one origin. Avoids
spinning up a second Vercel project just to host \`public/r/\`.

- \`.storybook/main.ts\` — add \`\"../public\"\` to \`staticDirs\` so storybook's
  build step copies \`public/r/*.json\` into \`storybook-static/r/\`.
- \`vercel.json\` — prepend \`npm run registry:build\` to \`buildCommand\` so
  the JSON files exist before storybook build copies them.
- \`README.md\` — replace \`<your-host>\` placeholders with the production
  URL (\`https://gymnopedies.shoota.work\`) and document the coexistence.

## After deploy

| URL | content |
|---|---|
| \`https://gymnopedies.shoota.work/\` | Storybook UI (unchanged) |
| \`https://gymnopedies.shoota.work/r/gymnopedies.json\` | registry preset |
| \`https://gymnopedies.shoota.work/r/article.json\` | individual items |
| \`https://gymnopedies.shoota.work/r/<name>.json\` | one per ui/blog component |

Consumers can install with e.g.

\`\`\`bash
npx shadcn@latest add https://gymnopedies.shoota.work/r/gymnopedies.json
\`\`\`

## Test plan

- [x] Local build: \`rm -rf storybook-static public/r && npm run registry:build && npm run build-storybook\` → \`storybook-static/r/\` contains 49 JSON files (45 registry items + auxiliary).
- [x] \`npm run typecheck\` / \`npm run lint\`
- [ ] Vercel preview: after merge, verify \`https://gymnopedies.shoota.work/r/article.json\` returns 200 with valid shadcn registry-item JSON
- [ ] Smoke test: \`npx shadcn@latest add https://gymnopedies.shoota.work/r/article.json\` in a fresh Vite + Tailwind v4 + path-alias project succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)