### PR TITLE
chore(ci): registry drift guard + fix chromatic workflow trigger

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,8 +1,9 @@
 name: "Chromatic"
 
-on: push
-  branches:
-    - main
+on:
+  push:
+    branches:
+      - main
 
 jobs:
   chromatic:
@@ -14,7 +15,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --include=optional
 
       - name: Run Chromatic
         uses: chromaui/action@latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,22 @@ jobs:
         uses: ./.github/actions/setupNode
       - name: Typecheck
         run: npm run typecheck
+
+  registry:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Install Node.js and dependencies
+        uses: ./.github/actions/setupNode
+      - name: Rebuild registry artifacts
+        run: npm run registry:build
+      - name: Fail if registry.json or public/r/ drifted from committed files
+        run: |
+          if ! git diff --quiet -- registry.json public/r; then
+            echo "::error::registry artifacts are out of sync with src/components/{ui,blog}/."
+            echo "Run 'npm run registry:build' locally and commit registry.json + public/r/."
+            git diff --stat -- registry.json public/r
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Post-release CI polish:

1. **ci.yml** — add a \`registry\` job that re-runs \`npm run registry:build\` on
   every PR and fails if \`registry.json\` or \`public/r/\` end up out of sync
   with the committed artifacts. Stops the registry from silently drifting
   away from \`src/components/{ui,blog}\`.

2. **chromatic.yml** — fix the \`on:\` block. The previous YAML was:

       on: push
         branches:
           - main

   which parses as \`on: \"push\"\` (string) with a dangling \`branches:\` key,
   so the workflow never actually matched any push to \`main\`. The merge of
   PR #205 / #210 *should* have re-baselined Chromatic on main but didn't,
   for that exact reason. Fixed to the proper nested form. Also switched
   the install step to \`npm ci --include=optional\` so the Rollup Linux
   native binary lands on the runner (same gotcha hit on Vercel).

## After merge

- Next push to \`main\` will trigger Chromatic with \`autoAcceptChanges: \"main\"\`,
  resetting the visual baseline to v1.0.0 automatically.
- Every PR will now have lint / typecheck / registry as required checks.

## Test plan

- [x] Local \`npm run registry:build\` finishes clean with the committed
      artifacts → drift check passes.
- [ ] Reviewer: confirm the new \`registry\` job runs green on this PR.
- [ ] Reviewer: after merge, confirm the Chromatic workflow triggers on
      \`main\` and re-baseline runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)