### PR TITLE
fix(registry): populate component dependencies in registry JSON

### DIFF
--- a/public/r/accordion.json
+++ b/public/r/accordion.json
@@ -3,6 +3,10 @@
   "name": "accordion",
   "title": "Accordion",
   "description": "Accordion — gymnopédies-themed shadcn primitive.",
+  "dependencies": [
+    "@base-ui/react",
+    "lucide-react"
+  ],
   "registryDependencies": [
     "utils"
   ],

--- a/public/r/alert-dialog.json
+++ b/public/r/alert-dialog.json
@@ -3,6 +3,9 @@
   "name": "alert-dialog",
   "title": "Alert Dialog",
   "description": "Alert Dialog — gymnopédies-themed shadcn primitive.",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "registryDependencies": [
     "utils"
   ],

--- a/public/r/alert.json
+++ b/public/r/alert.json
@@ -3,6 +3,9 @@
   "name": "alert",
   "title": "Alert",
   "description": "Alert — gymnopédies-themed shadcn primitive.",
+  "dependencies": [
+    "class-variance-authority"
+  ],
   "registryDependencies": [
     "utils"
   ],

--- a/public/r/avatar.json
+++ b/public/r/avatar.json
@@ -3,6 +3,9 @@
   "name": "avatar",
   "title": "Avatar",
   "description": "Avatar — gymnopédies-themed shadcn primitive.",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "registryDependencies": [
     "utils"
   ],

--- a/public/r/badge.json
+++ b/public/r/badge.json
@@ -3,6 +3,10 @@
   "name": "badge",
   "title": "Badge",
   "description": "Badge — gymnopédies-themed shadcn primitive.",
+  "dependencies": [
+    "@base-ui/react",
+    "class-variance-authority"
+  ],
   "registryDependencies": [
     "utils"
   ],

--- a/public/r/breadcrumb.json
+++ b/public/r/breadcrumb.json
@@ -3,6 +3,10 @@
   "name": "breadcrumb",
   "title": "Breadcrumb",
   "description": "Breadcrumb — gymnopédies-themed shadcn primitive.",
+  "dependencies": [
+    "@base-ui/react",
+    "lucide-react"
+  ],
   "registryDependencies": [
     "utils"
   ],

--- a/public/r/button.json
+++ b/public/r/button.json
@@ -3,6 +3,10 @@
   "name": "button",
   "title": "Button",
   "description": "Button — gymnopédies-themed shadcn primitive.",
+  "dependencies": [
+    "@base-ui/react",
+    "class-variance-authority"
+  ],
   "registryDependencies": [
     "utils"
   ],

--- a/public/r/carousel.json
+++ b/public/r/carousel.json
@@ -3,6 +3,10 @@
   "name": "carousel",
   "title": "Carousel",
   "description": "Carousel — gymnopédies-themed shadcn primitive.",
+  "dependencies": [
+    "embla-carousel-react",
+    "lucide-react"
+  ],
   "registryDependencies": [
     "utils"
   ],

--- a/public/r/chart.json
+++ b/public/r/chart.json
@@ -3,6 +3,9 @@
   "name": "chart",
   "title": "Chart",
   "description": "Chart — gymnopédies-themed shadcn primitive.",
+  "dependencies": [
+    "recharts"
+  ],
   "registryDependencies": [
     "utils"
   ],

--- a/public/r/collapsible.json
+++ b/public/r/collapsible.json
@@ -3,6 +3,9 @@
   "name": "collapsible",
   "title": "Collapsible",
   "description": "Collapsible — gymnopédies-themed shadcn primitive.",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "registryDependencies": [
     "utils"
   ],

--- a/public/r/command.json
+++ b/public/r/command.json
@@ -3,6 +3,10 @@
   "name": "command",
   "title": "Command",
   "description": "Command — gymnopédies-themed shadcn primitive.",
+  "dependencies": [
+    "cmdk",
+    "lucide-react"
+  ],
   "registryDependencies": [
     "utils"
   ],

--- a/public/r/context-menu.json
+++ b/public/r/context-menu.json
@@ -3,6 +3,10 @@
   "name": "context-menu",
   "title": "Context Menu",
   "description": "Context Menu — gymnopédies-themed shadcn primitive.",
+  "dependencies": [
+    "@base-ui/react",
+    "lucide-react"
+  ],
   "registryDependencies": [
     "utils"
   ],

--- a/public/r/dialog.json
+++ b/public/r/dialog.json
@@ -3,6 +3,10 @@
   "name": "dialog",
   "title": "Dialog",
   "description": "Dialog — gymnopédies-themed shadcn primitive.",
+  "dependencies": [
+    "@base-ui/react",
+    "lucide-react"
+  ],
   "registryDependencies": [
     "utils"
   ],

--- a/public/r/drawer.json
+++ b/public/r/drawer.json
@@ -3,6 +3,9 @@
   "name": "drawer",
   "title": "Drawer",
   "description": "Drawer — gymnopédies-themed shadcn primitive.",
+  "dependencies": [
+    "vaul"
+  ],
   "registryDependencies": [
     "utils"
   ],

--- a/public/r/dropdown-menu.json
+++ b/public/r/dropdown-menu.json
@@ -3,6 +3,10 @@
   "name": "dropdown-menu",
   "title": "Dropdown Menu",
   "description": "Dropdown Menu — gymnopédies-themed shadcn primitive.",
+  "dependencies": [
+    "@base-ui/react",
+    "lucide-react"
+  ],
   "registryDependencies": [
     "utils"
   ],

--- a/public/r/hover-card.json
+++ b/public/r/hover-card.json
@@ -3,6 +3,9 @@
   "name": "hover-card",
   "title": "Hover Card",
   "description": "Hover Card — gymnopédies-themed shadcn primitive.",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "registryDependencies": [
     "utils"
   ],

--- a/public/r/input-group.json
+++ b/public/r/input-group.json
@@ -3,6 +3,9 @@
   "name": "input-group",
   "title": "Input Group",
   "description": "Input Group — gymnopédies-themed shadcn primitive.",
+  "dependencies": [
+    "class-variance-authority"
+  ],
   "registryDependencies": [
     "utils"
   ],

--- a/public/r/input.json
+++ b/public/r/input.json
@@ -3,6 +3,9 @@
   "name": "input",
   "title": "Input",
   "description": "Input — gymnopédies-themed shadcn primitive.",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "registryDependencies": [
     "utils"
   ],

--- a/public/r/menubar.json
+++ b/public/r/menubar.json
@@ -3,6 +3,10 @@
   "name": "menubar",
   "title": "Menubar",
   "description": "Menubar — gymnopédies-themed shadcn primitive.",
+  "dependencies": [
+    "@base-ui/react",
+    "lucide-react"
+  ],
   "registryDependencies": [
     "utils"
   ],

--- a/public/r/navigation-menu.json
+++ b/public/r/navigation-menu.json
@@ -3,6 +3,11 @@
   "name": "navigation-menu",
   "title": "Navigation Menu",
   "description": "Navigation Menu — gymnopédies-themed shadcn primitive.",
+  "dependencies": [
+    "@base-ui/react",
+    "class-variance-authority",
+    "lucide-react"
+  ],
   "registryDependencies": [
     "utils"
   ],

--- a/public/r/pagination.json
+++ b/public/r/pagination.json
@@ -3,6 +3,9 @@
   "name": "pagination",
   "title": "Pagination",
   "description": "Pagination — gymnopédies-themed shadcn primitive.",
+  "dependencies": [
+    "lucide-react"
+  ],
   "registryDependencies": [
     "utils"
   ],

--- a/public/r/popover.json
+++ b/public/r/popover.json
@@ -3,6 +3,9 @@
   "name": "popover",
   "title": "Popover",
   "description": "Popover — gymnopédies-themed shadcn primitive.",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "registryDependencies": [
     "utils"
   ],

--- a/public/r/progress.json
+++ b/public/r/progress.json
@@ -3,6 +3,9 @@
   "name": "progress",
   "title": "Progress",
   "description": "Progress — gymnopédies-themed shadcn primitive.",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "registryDependencies": [
     "utils"
   ],

--- a/public/r/registry.json
+++ b/public/r/registry.json
@@ -91,6 +91,10 @@
           "type": "registry:ui"
         }
       ],
+      "dependencies": [
+        "@base-ui/react",
+        "lucide-react"
+      ],
       "registryDependencies": [
         "utils"
       ]
@@ -106,6 +110,9 @@
           "type": "registry:ui"
         }
       ],
+      "dependencies": [
+        "class-variance-authority"
+      ],
       "registryDependencies": [
         "utils"
       ]
@@ -120,6 +127,9 @@
           "path": "src/components/ui/alert-dialog.tsx",
           "type": "registry:ui"
         }
+      ],
+      "dependencies": [
+        "@base-ui/react"
       ],
       "registryDependencies": [
         "utils"
@@ -151,6 +161,9 @@
           "type": "registry:ui"
         }
       ],
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "registryDependencies": [
         "utils"
       ]
@@ -165,6 +178,10 @@
           "path": "src/components/ui/badge.tsx",
           "type": "registry:ui"
         }
+      ],
+      "dependencies": [
+        "@base-ui/react",
+        "class-variance-authority"
       ],
       "registryDependencies": [
         "utils"
@@ -181,6 +198,10 @@
           "type": "registry:ui"
         }
       ],
+      "dependencies": [
+        "@base-ui/react",
+        "lucide-react"
+      ],
       "registryDependencies": [
         "utils"
       ]
@@ -195,6 +216,10 @@
           "path": "src/components/ui/button.tsx",
           "type": "registry:ui"
         }
+      ],
+      "dependencies": [
+        "@base-ui/react",
+        "class-variance-authority"
       ],
       "registryDependencies": [
         "utils"
@@ -226,6 +251,10 @@
           "type": "registry:ui"
         }
       ],
+      "dependencies": [
+        "embla-carousel-react",
+        "lucide-react"
+      ],
       "registryDependencies": [
         "utils"
       ]
@@ -240,6 +269,9 @@
           "path": "src/components/ui/chart.tsx",
           "type": "registry:ui"
         }
+      ],
+      "dependencies": [
+        "recharts"
       ],
       "registryDependencies": [
         "utils"
@@ -256,6 +288,9 @@
           "type": "registry:ui"
         }
       ],
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "registryDependencies": [
         "utils"
       ]
@@ -270,6 +305,10 @@
           "path": "src/components/ui/command.tsx",
           "type": "registry:ui"
         }
+      ],
+      "dependencies": [
+        "cmdk",
+        "lucide-react"
       ],
       "registryDependencies": [
         "utils"
@@ -286,6 +325,10 @@
           "type": "registry:ui"
         }
       ],
+      "dependencies": [
+        "@base-ui/react",
+        "lucide-react"
+      ],
       "registryDependencies": [
         "utils"
       ]
@@ -300,6 +343,10 @@
           "path": "src/components/ui/dialog.tsx",
           "type": "registry:ui"
         }
+      ],
+      "dependencies": [
+        "@base-ui/react",
+        "lucide-react"
       ],
       "registryDependencies": [
         "utils"
@@ -316,6 +363,9 @@
           "type": "registry:ui"
         }
       ],
+      "dependencies": [
+        "vaul"
+      ],
       "registryDependencies": [
         "utils"
       ]
@@ -330,6 +380,10 @@
           "path": "src/components/ui/dropdown-menu.tsx",
           "type": "registry:ui"
         }
+      ],
+      "dependencies": [
+        "@base-ui/react",
+        "lucide-react"
       ],
       "registryDependencies": [
         "utils"
@@ -346,6 +400,9 @@
           "type": "registry:ui"
         }
       ],
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "registryDependencies": [
         "utils"
       ]
@@ -360,6 +417,9 @@
           "path": "src/components/ui/input.tsx",
           "type": "registry:ui"
         }
+      ],
+      "dependencies": [
+        "@base-ui/react"
       ],
       "registryDependencies": [
         "utils"
@@ -376,6 +436,9 @@
           "type": "registry:ui"
         }
       ],
+      "dependencies": [
+        "class-variance-authority"
+      ],
       "registryDependencies": [
         "utils"
       ]
@@ -390,6 +453,10 @@
           "path": "src/components/ui/menubar.tsx",
           "type": "registry:ui"
         }
+      ],
+      "dependencies": [
+        "@base-ui/react",
+        "lucide-react"
       ],
       "registryDependencies": [
         "utils"
@@ -406,6 +473,11 @@
           "type": "registry:ui"
         }
       ],
+      "dependencies": [
+        "@base-ui/react",
+        "class-variance-authority",
+        "lucide-react"
+      ],
       "registryDependencies": [
         "utils"
       ]
@@ -420,6 +492,9 @@
           "path": "src/components/ui/pagination.tsx",
           "type": "registry:ui"
         }
+      ],
+      "dependencies": [
+        "lucide-react"
       ],
       "registryDependencies": [
         "utils"
@@ -436,6 +511,9 @@
           "type": "registry:ui"
         }
       ],
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "registryDependencies": [
         "utils"
       ]
@@ -450,6 +528,9 @@
           "path": "src/components/ui/progress.tsx",
           "type": "registry:ui"
         }
+      ],
+      "dependencies": [
+        "@base-ui/react"
       ],
       "registryDependencies": [
         "utils"
@@ -466,6 +547,9 @@
           "type": "registry:ui"
         }
       ],
+      "dependencies": [
+        "react-resizable-panels"
+      ],
       "registryDependencies": [
         "utils"
       ]
@@ -480,6 +564,9 @@
           "path": "src/components/ui/scroll-area.tsx",
           "type": "registry:ui"
         }
+      ],
+      "dependencies": [
+        "@base-ui/react"
       ],
       "registryDependencies": [
         "utils"
@@ -496,6 +583,9 @@
           "type": "registry:ui"
         }
       ],
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "registryDependencies": [
         "utils"
       ]
@@ -511,6 +601,10 @@
           "type": "registry:ui"
         }
       ],
+      "dependencies": [
+        "@base-ui/react",
+        "lucide-react"
+      ],
       "registryDependencies": [
         "utils"
       ]
@@ -525,6 +619,11 @@
           "path": "src/components/ui/sidebar.tsx",
           "type": "registry:ui"
         }
+      ],
+      "dependencies": [
+        "@base-ui/react",
+        "class-variance-authority",
+        "lucide-react"
       ],
       "registryDependencies": [
         "utils"
@@ -556,6 +655,11 @@
           "type": "registry:ui"
         }
       ],
+      "dependencies": [
+        "lucide-react",
+        "next-themes",
+        "sonner"
+      ],
       "registryDependencies": [
         "utils"
       ]
@@ -585,6 +689,10 @@
           "path": "src/components/ui/tabs.tsx",
           "type": "registry:ui"
         }
+      ],
+      "dependencies": [
+        "@base-ui/react",
+        "class-variance-authority"
       ],
       "registryDependencies": [
         "utils"
@@ -616,6 +724,10 @@
           "type": "registry:ui"
         }
       ],
+      "dependencies": [
+        "@base-ui/react",
+        "class-variance-authority"
+      ],
       "registryDependencies": [
         "utils"
       ]
@@ -631,6 +743,10 @@
           "type": "registry:ui"
         }
       ],
+      "dependencies": [
+        "@base-ui/react",
+        "class-variance-authority"
+      ],
       "registryDependencies": [
         "utils"
       ]
@@ -645,6 +761,9 @@
           "path": "src/components/ui/tooltip.tsx",
           "type": "registry:ui"
         }
+      ],
+      "dependencies": [
+        "@base-ui/react"
       ],
       "registryDependencies": [
         "utils"
@@ -693,12 +812,12 @@
           "type": "registry:component"
         }
       ],
+      "dependencies": [
+        "date-fns"
+      ],
       "registryDependencies": [
         "utils",
         "theme"
-      ],
-      "dependencies": [
-        "date-fns"
       ]
     },
     {

--- a/public/r/resizable.json
+++ b/public/r/resizable.json
@@ -3,6 +3,9 @@
   "name": "resizable",
   "title": "Resizable",
   "description": "Resizable — gymnopédies-themed shadcn primitive.",
+  "dependencies": [
+    "react-resizable-panels"
+  ],
   "registryDependencies": [
     "utils"
   ],

--- a/public/r/scroll-area.json
+++ b/public/r/scroll-area.json
@@ -3,6 +3,9 @@
   "name": "scroll-area",
   "title": "Scroll Area",
   "description": "Scroll Area — gymnopédies-themed shadcn primitive.",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "registryDependencies": [
     "utils"
   ],

--- a/public/r/separator.json
+++ b/public/r/separator.json
@@ -3,6 +3,9 @@
   "name": "separator",
   "title": "Separator",
   "description": "Separator — gymnopédies-themed shadcn primitive.",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "registryDependencies": [
     "utils"
   ],

--- a/public/r/sheet.json
+++ b/public/r/sheet.json
@@ -3,6 +3,10 @@
   "name": "sheet",
   "title": "Sheet",
   "description": "Sheet — gymnopédies-themed shadcn primitive.",
+  "dependencies": [
+    "@base-ui/react",
+    "lucide-react"
+  ],
   "registryDependencies": [
     "utils"
   ],

--- a/public/r/sidebar.json
+++ b/public/r/sidebar.json
@@ -3,6 +3,11 @@
   "name": "sidebar",
   "title": "Sidebar",
   "description": "Sidebar — gymnopédies-themed shadcn primitive.",
+  "dependencies": [
+    "@base-ui/react",
+    "class-variance-authority",
+    "lucide-react"
+  ],
   "registryDependencies": [
     "utils"
   ],

--- a/public/r/sonner.json
+++ b/public/r/sonner.json
@@ -3,6 +3,11 @@
   "name": "sonner",
   "title": "Sonner",
   "description": "Sonner — gymnopédies-themed shadcn primitive.",
+  "dependencies": [
+    "lucide-react",
+    "next-themes",
+    "sonner"
+  ],
   "registryDependencies": [
     "utils"
   ],

--- a/public/r/tabs.json
+++ b/public/r/tabs.json
@@ -3,6 +3,10 @@
   "name": "tabs",
   "title": "Tabs",
   "description": "Tabs — gymnopédies-themed shadcn primitive.",
+  "dependencies": [
+    "@base-ui/react",
+    "class-variance-authority"
+  ],
   "registryDependencies": [
     "utils"
   ],

--- a/public/r/toggle-group.json
+++ b/public/r/toggle-group.json
@@ -3,6 +3,10 @@
   "name": "toggle-group",
   "title": "Toggle Group",
   "description": "Toggle Group — gymnopédies-themed shadcn primitive.",
+  "dependencies": [
+    "@base-ui/react",
+    "class-variance-authority"
+  ],
   "registryDependencies": [
     "utils"
   ],

--- a/public/r/toggle.json
+++ b/public/r/toggle.json
@@ -3,6 +3,10 @@
   "name": "toggle",
   "title": "Toggle",
   "description": "Toggle — gymnopédies-themed shadcn primitive.",
+  "dependencies": [
+    "@base-ui/react",
+    "class-variance-authority"
+  ],
   "registryDependencies": [
     "utils"
   ],

--- a/public/r/tooltip.json
+++ b/public/r/tooltip.json
@@ -3,6 +3,9 @@
   "name": "tooltip",
   "title": "Tooltip",
   "description": "Tooltip — gymnopédies-themed shadcn primitive.",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "registryDependencies": [
     "utils"
   ],

--- a/registry.json
+++ b/registry.json
@@ -91,6 +91,10 @@
           "type": "registry:ui"
         }
       ],
+      "dependencies": [
+        "@base-ui/react",
+        "lucide-react"
+      ],
       "registryDependencies": [
         "utils"
       ]
@@ -106,6 +110,9 @@
           "type": "registry:ui"
         }
       ],
+      "dependencies": [
+        "class-variance-authority"
+      ],
       "registryDependencies": [
         "utils"
       ]
@@ -120,6 +127,9 @@
           "path": "src/components/ui/alert-dialog.tsx",
           "type": "registry:ui"
         }
+      ],
+      "dependencies": [
+        "@base-ui/react"
       ],
       "registryDependencies": [
         "utils"
@@ -151,6 +161,9 @@
           "type": "registry:ui"
         }
       ],
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "registryDependencies": [
         "utils"
       ]
@@ -165,6 +178,10 @@
           "path": "src/components/ui/badge.tsx",
           "type": "registry:ui"
         }
+      ],
+      "dependencies": [
+        "@base-ui/react",
+        "class-variance-authority"
       ],
       "registryDependencies": [
         "utils"
@@ -181,6 +198,10 @@
           "type": "registry:ui"
         }
       ],
+      "dependencies": [
+        "@base-ui/react",
+        "lucide-react"
+      ],
       "registryDependencies": [
         "utils"
       ]
@@ -195,6 +216,10 @@
           "path": "src/components/ui/button.tsx",
           "type": "registry:ui"
         }
+      ],
+      "dependencies": [
+        "@base-ui/react",
+        "class-variance-authority"
       ],
       "registryDependencies": [
         "utils"
@@ -226,6 +251,10 @@
           "type": "registry:ui"
         }
       ],
+      "dependencies": [
+        "embla-carousel-react",
+        "lucide-react"
+      ],
       "registryDependencies": [
         "utils"
       ]
@@ -240,6 +269,9 @@
           "path": "src/components/ui/chart.tsx",
           "type": "registry:ui"
         }
+      ],
+      "dependencies": [
+        "recharts"
       ],
       "registryDependencies": [
         "utils"
@@ -256,6 +288,9 @@
           "type": "registry:ui"
         }
       ],
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "registryDependencies": [
         "utils"
       ]
@@ -270,6 +305,10 @@
           "path": "src/components/ui/command.tsx",
           "type": "registry:ui"
         }
+      ],
+      "dependencies": [
+        "cmdk",
+        "lucide-react"
       ],
       "registryDependencies": [
         "utils"
@@ -286,6 +325,10 @@
           "type": "registry:ui"
         }
       ],
+      "dependencies": [
+        "@base-ui/react",
+        "lucide-react"
+      ],
       "registryDependencies": [
         "utils"
       ]
@@ -300,6 +343,10 @@
           "path": "src/components/ui/dialog.tsx",
           "type": "registry:ui"
         }
+      ],
+      "dependencies": [
+        "@base-ui/react",
+        "lucide-react"
       ],
       "registryDependencies": [
         "utils"
@@ -316,6 +363,9 @@
           "type": "registry:ui"
         }
       ],
+      "dependencies": [
+        "vaul"
+      ],
       "registryDependencies": [
         "utils"
       ]
@@ -330,6 +380,10 @@
           "path": "src/components/ui/dropdown-menu.tsx",
           "type": "registry:ui"
         }
+      ],
+      "dependencies": [
+        "@base-ui/react",
+        "lucide-react"
       ],
       "registryDependencies": [
         "utils"
@@ -346,6 +400,9 @@
           "type": "registry:ui"
         }
       ],
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "registryDependencies": [
         "utils"
       ]
@@ -360,6 +417,9 @@
           "path": "src/components/ui/input.tsx",
           "type": "registry:ui"
         }
+      ],
+      "dependencies": [
+        "@base-ui/react"
       ],
       "registryDependencies": [
         "utils"
@@ -376,6 +436,9 @@
           "type": "registry:ui"
         }
       ],
+      "dependencies": [
+        "class-variance-authority"
+      ],
       "registryDependencies": [
         "utils"
       ]
@@ -390,6 +453,10 @@
           "path": "src/components/ui/menubar.tsx",
           "type": "registry:ui"
         }
+      ],
+      "dependencies": [
+        "@base-ui/react",
+        "lucide-react"
       ],
       "registryDependencies": [
         "utils"
@@ -406,6 +473,11 @@
           "type": "registry:ui"
         }
       ],
+      "dependencies": [
+        "@base-ui/react",
+        "class-variance-authority",
+        "lucide-react"
+      ],
       "registryDependencies": [
         "utils"
       ]
@@ -420,6 +492,9 @@
           "path": "src/components/ui/pagination.tsx",
           "type": "registry:ui"
         }
+      ],
+      "dependencies": [
+        "lucide-react"
       ],
       "registryDependencies": [
         "utils"
@@ -436,6 +511,9 @@
           "type": "registry:ui"
         }
       ],
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "registryDependencies": [
         "utils"
       ]
@@ -450,6 +528,9 @@
           "path": "src/components/ui/progress.tsx",
           "type": "registry:ui"
         }
+      ],
+      "dependencies": [
+        "@base-ui/react"
       ],
       "registryDependencies": [
         "utils"
@@ -466,6 +547,9 @@
           "type": "registry:ui"
         }
       ],
+      "dependencies": [
+        "react-resizable-panels"
+      ],
       "registryDependencies": [
         "utils"
       ]
@@ -480,6 +564,9 @@
           "path": "src/components/ui/scroll-area.tsx",
           "type": "registry:ui"
         }
+      ],
+      "dependencies": [
+        "@base-ui/react"
       ],
       "registryDependencies": [
         "utils"
@@ -496,6 +583,9 @@
           "type": "registry:ui"
         }
       ],
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "registryDependencies": [
         "utils"
       ]
@@ -511,6 +601,10 @@
           "type": "registry:ui"
         }
       ],
+      "dependencies": [
+        "@base-ui/react",
+        "lucide-react"
+      ],
       "registryDependencies": [
         "utils"
       ]
@@ -525,6 +619,11 @@
           "path": "src/components/ui/sidebar.tsx",
           "type": "registry:ui"
         }
+      ],
+      "dependencies": [
+        "@base-ui/react",
+        "class-variance-authority",
+        "lucide-react"
       ],
       "registryDependencies": [
         "utils"
@@ -556,6 +655,11 @@
           "type": "registry:ui"
         }
       ],
+      "dependencies": [
+        "lucide-react",
+        "next-themes",
+        "sonner"
+      ],
       "registryDependencies": [
         "utils"
       ]
@@ -585,6 +689,10 @@
           "path": "src/components/ui/tabs.tsx",
           "type": "registry:ui"
         }
+      ],
+      "dependencies": [
+        "@base-ui/react",
+        "class-variance-authority"
       ],
       "registryDependencies": [
         "utils"
@@ -616,6 +724,10 @@
           "type": "registry:ui"
         }
       ],
+      "dependencies": [
+        "@base-ui/react",
+        "class-variance-authority"
+      ],
       "registryDependencies": [
         "utils"
       ]
@@ -631,6 +743,10 @@
           "type": "registry:ui"
         }
       ],
+      "dependencies": [
+        "@base-ui/react",
+        "class-variance-authority"
+      ],
       "registryDependencies": [
         "utils"
       ]
@@ -645,6 +761,9 @@
           "path": "src/components/ui/tooltip.tsx",
           "type": "registry:ui"
         }
+      ],
+      "dependencies": [
+        "@base-ui/react"
       ],
       "registryDependencies": [
         "utils"
@@ -693,12 +812,12 @@
           "type": "registry:component"
         }
       ],
+      "dependencies": [
+        "date-fns"
+      ],
       "registryDependencies": [
         "utils",
         "theme"
-      ],
-      "dependencies": [
-        "date-fns"
       ]
     },
     {

--- a/scripts/build-registry.ts
+++ b/scripts/build-registry.ts
@@ -9,7 +9,7 @@
  * Run with `npm run registry:build` to also produce public/r/*.json via the shadcn CLI.
  */
 
-import { readdirSync, writeFileSync } from "node:fs"
+import { readdirSync, readFileSync, writeFileSync } from "node:fs"
 import { join, basename } from "node:path"
 
 type RegistryItemType =
@@ -53,6 +53,33 @@ const componentFiles = (dir: string) =>
     .filter((f) => f.endsWith(".tsx") && !f.endsWith(".stories.tsx"))
     .map((f) => basename(f, ".tsx"))
     .sort()
+
+// Peer-installed by the consumer; never list these as registry deps.
+const PEER_PACKAGES = new Set(["react", "react-dom"])
+
+const IMPORT_RE = /(?:^|\n)\s*import\s+(?:[^"';]*?\s+from\s+)?["']([^"']+)["']/g
+
+const extractExternalDeps = (filePath: string): string[] => {
+  const src = readFileSync(filePath, "utf8")
+  const deps = new Set<string>()
+  for (const match of src.matchAll(IMPORT_RE)) {
+    const spec = match[1]
+    if (
+      spec.startsWith(".") ||
+      spec.startsWith("@/") ||
+      spec.startsWith("node:")
+    ) {
+      continue
+    }
+    const parts = spec.split("/")
+    const pkgName = spec.startsWith("@")
+      ? parts.slice(0, 2).join("/")
+      : parts[0]
+    if (PEER_PACKAGES.has(pkgName)) continue
+    deps.add(pkgName)
+  }
+  return [...deps].sort()
+}
 
 const utilItem: RegistryItem = {
   name: "utils",
@@ -121,26 +148,35 @@ const themeItem: RegistryItem = {
   },
 }
 
-const uiItems: RegistryItem[] = componentFiles(UI_DIR).map((name) => ({
-  name,
-  type: "registry:ui",
-  title: toTitle(name),
-  description: `${toTitle(name)} — gymnopédies-themed shadcn primitive.`,
-  files: [{ path: `src/components/ui/${name}.tsx`, type: "registry:ui" }],
-  registryDependencies: ["utils"],
-}))
+const uiItems: RegistryItem[] = componentFiles(UI_DIR).map((name) => {
+  const filePath = join(UI_DIR, `${name}.tsx`)
+  const dependencies = extractExternalDeps(filePath)
+  return {
+    name,
+    type: "registry:ui",
+    title: toTitle(name),
+    description: `${toTitle(name)} — gymnopédies-themed shadcn primitive.`,
+    files: [{ path: `src/components/ui/${name}.tsx`, type: "registry:ui" }],
+    ...(dependencies.length > 0 ? { dependencies } : {}),
+    registryDependencies: ["utils"],
+  }
+})
 
-const blogItems: RegistryItem[] = componentFiles(BLOG_DIR).map((name) => ({
-  name,
-  type: "registry:component",
-  title: toTitle(name),
-  description: `${toTitle(name)} — gymnopédies blog reading primitive.`,
-  files: [
-    { path: `src/components/blog/${name}.tsx`, type: "registry:component" },
-  ],
-  registryDependencies: ["utils", "theme"],
-  ...(name === "date-time" ? { dependencies: ["date-fns"] } : {}),
-}))
+const blogItems: RegistryItem[] = componentFiles(BLOG_DIR).map((name) => {
+  const filePath = join(BLOG_DIR, `${name}.tsx`)
+  const dependencies = extractExternalDeps(filePath)
+  return {
+    name,
+    type: "registry:component",
+    title: toTitle(name),
+    description: `${toTitle(name)} — gymnopédies blog reading primitive.`,
+    files: [
+      { path: `src/components/blog/${name}.tsx`, type: "registry:component" },
+    ],
+    ...(dependencies.length > 0 ? { dependencies } : {}),
+    registryDependencies: ["utils", "theme"],
+  }
+})
 
 const presetItem: RegistryItem = {
   name: "gymnopedies",


### PR DESCRIPTION
## Summary

利用者から「`npx shadcn add` で入れた `button.tsx` が `@base-ui/react` / `class-variance-authority` を import しているのに `package.json` にも `node_modules` にも入っておらず、import エラーになる」というフィードバックがありました。

原因は `scripts/build-registry.ts` が `registry:ui` / `registry:component` の各アイテムを **`dependencies` フィールド空** で出力していたこと。shadcn CLI は `dependencies` に列挙された npm パッケージしか install しないため、消費側プロジェクトでコンポーネントがコンパイルできませんでした。

監査したところ **45 アイテム中 33 個**が依存欠落（`button` / `badge` / `separator` / `accordion` / `carousel` ...ほぼ全 UI primitive）。

## 修正内容

- `build-registry.ts` に、各コンポーネントの `import` 文を走査して外部 npm パッケージを自動抽出する処理を追加
  - scoped package（`@base-ui/react/button` → `@base-ui/react`）はパッケージルートに集約
  - `react` / `react-dom` は peer dep として除外
  - `@/` エイリアスと `node:` 組み込みは除外
- 旧来の `date-time` 向け `date-fns` ハードコード特例を削除（スキャンで拾われるため不要）
- `registry.json` と `public/r/*.json` を再生成（34 ファイル更新）

### 検証

- 監査スクリプト再実行で `missing_count: 0`
- `button.json` → `["@base-ui/react", "class-variance-authority"]`
- `carousel.json` → `["embla-carousel-react", "lucide-react"]`
- `npm run typecheck` / `npm run lint` パス

## Test plan

- [x] `npm run registry:build` で registry.json + public/r/*.json 再生成
- [x] 全 registry:ui / registry:component アイテムの dependencies が実 import と一致
- [x] typecheck / lint
- [ ] マージ後、`npx shadcn@latest add https://gymnopedies.shoota.work/r/button.json` でクリーンなプロジェクトに入れて依存が自動 install されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)