### PR TITLE
chore(release): bump to v1.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,16 @@ There is no compatibility shim. If you are still on `gymnopedies@0.1.x` (Emotion
 
 ## Release notes
 
+- **v1.1.1** — registry dependency fix
+  - `registry.json` / `public/r/*.json` now list each component's npm
+    dependencies (`@base-ui/react`, `class-variance-authority`,
+    `lucide-react`, `embla-carousel-react`, …). Previously these fields were
+    empty, so `npx shadcn add` installed the component source without the
+    packages it imports — 33 of 45 items were affected, including `button`,
+    `badge` and `separator`.
+  - `scripts/build-registry.ts` now derives the dependency list by scanning
+    each component's `import` statements, so the registry stays correct as
+    components change.
 - **v1.1.0** — sample blog published alongside the Storybook
   - New **Quiet Pages** sample site under `examples/blog/`, deployed on the
     same domain at <https://gymnopedies.shoota.work/examples/blog/>.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gymnopedies",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gymnopedies",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@base-ui/react": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gymnopedies",
   "private": false,
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "author": {
     "name": "shoota"


### PR DESCRIPTION
## Summary

#226（registry の dependencies 欠落修正）に対する patch リリース用の version bump です。

- `package.json` / `package-lock.json`: `1.1.0` → `1.1.1`
- `README.md` の Release notes に v1.1.1 を追加

## Test plan

- [x] `npm version 1.1.1 --no-git-tag-version`
- [ ] マージ後に `v1.1.1` タグ + GitHub Release を作成

🤖 Generated with [Claude Code](https://claude.com/claude-code)