### PR TITLE
fix(registry): publish hook files imported by components

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,11 @@ There is no compatibility shim. If you are still on `gymnopedies@0.1.x` (Emotion
     registry — so `npx shadcn add` pulled official shadcn components instead
     of the gymnopédies-themed ones, and failed on items with no upstream
     equivalent (`hero`, `article`, `theme`, …).
+  - `src/hooks/*` are now published as `registry:hook` items and wired into
+    the `registryDependencies` of the components that import them via
+    `@/hooks/*`. `sidebar` imports `@/hooks/use-mobile`, which the registry
+    previously omitted entirely — installing `sidebar` produced a project
+    that failed to typecheck (`Cannot find module '@/hooks/use-mobile'`).
 - **v1.1.1** — registry dependency fix
   - `registry.json` / `public/r/*.json` now list each component's npm
     dependencies (`@base-ui/react`, `class-variance-authority`,

--- a/public/r/gymnopedies.json
+++ b/public/r/gymnopedies.json
@@ -50,7 +50,8 @@
     "https://gymnopedies.shoota.work/r/global-styles.json",
     "https://gymnopedies.shoota.work/r/header-navigation.json",
     "https://gymnopedies.shoota.work/r/hero.json",
-    "https://gymnopedies.shoota.work/r/picture.json"
+    "https://gymnopedies.shoota.work/r/picture.json",
+    "https://gymnopedies.shoota.work/r/use-mobile.json"
   ],
   "type": "registry:style"
 }

--- a/public/r/registry.json
+++ b/public/r/registry.json
@@ -626,7 +626,8 @@
         "lucide-react"
       ],
       "registryDependencies": [
-        "https://gymnopedies.shoota.work/r/utils.json"
+        "https://gymnopedies.shoota.work/r/utils.json",
+        "https://gymnopedies.shoota.work/r/use-mobile.json"
       ]
     },
     {
@@ -885,6 +886,18 @@
       ]
     },
     {
+      "name": "use-mobile",
+      "type": "registry:hook",
+      "title": "Use Mobile",
+      "description": "Use Mobile — gymnopédies hook.",
+      "files": [
+        {
+          "path": "src/hooks/use-mobile.ts",
+          "type": "registry:hook"
+        }
+      ]
+    },
+    {
       "name": "gymnopedies",
       "type": "registry:style",
       "title": "Gymnopédies — read-only design system",
@@ -936,7 +949,8 @@
         "https://gymnopedies.shoota.work/r/global-styles.json",
         "https://gymnopedies.shoota.work/r/header-navigation.json",
         "https://gymnopedies.shoota.work/r/hero.json",
-        "https://gymnopedies.shoota.work/r/picture.json"
+        "https://gymnopedies.shoota.work/r/picture.json",
+        "https://gymnopedies.shoota.work/r/use-mobile.json"
       ]
     }
   ]

--- a/public/r/sidebar.json
+++ b/public/r/sidebar.json
@@ -9,7 +9,8 @@
     "lucide-react"
   ],
   "registryDependencies": [
-    "https://gymnopedies.shoota.work/r/utils.json"
+    "https://gymnopedies.shoota.work/r/utils.json",
+    "https://gymnopedies.shoota.work/r/use-mobile.json"
   ],
   "files": [
     {

--- a/public/r/use-mobile.json
+++ b/public/r/use-mobile.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "use-mobile",
+  "title": "Use Mobile",
+  "description": "Use Mobile — gymnopédies hook.",
+  "files": [
+    {
+      "path": "src/hooks/use-mobile.ts",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "type": "registry:hook"
+    }
+  ],
+  "type": "registry:hook"
+}

--- a/registry.json
+++ b/registry.json
@@ -626,7 +626,8 @@
         "lucide-react"
       ],
       "registryDependencies": [
-        "https://gymnopedies.shoota.work/r/utils.json"
+        "https://gymnopedies.shoota.work/r/utils.json",
+        "https://gymnopedies.shoota.work/r/use-mobile.json"
       ]
     },
     {
@@ -885,6 +886,18 @@
       ]
     },
     {
+      "name": "use-mobile",
+      "type": "registry:hook",
+      "title": "Use Mobile",
+      "description": "Use Mobile — gymnopédies hook.",
+      "files": [
+        {
+          "path": "src/hooks/use-mobile.ts",
+          "type": "registry:hook"
+        }
+      ]
+    },
+    {
       "name": "gymnopedies",
       "type": "registry:style",
       "title": "Gymnopédies — read-only design system",
@@ -936,7 +949,8 @@
         "https://gymnopedies.shoota.work/r/global-styles.json",
         "https://gymnopedies.shoota.work/r/header-navigation.json",
         "https://gymnopedies.shoota.work/r/hero.json",
-        "https://gymnopedies.shoota.work/r/picture.json"
+        "https://gymnopedies.shoota.work/r/picture.json",
+        "https://gymnopedies.shoota.work/r/use-mobile.json"
       ]
     }
   ]

--- a/scripts/build-registry.ts
+++ b/scripts/build-registry.ts
@@ -4,6 +4,8 @@
  *
  * - Scans src/components/ui/*.tsx (excluding *.stories.tsx) as registry:ui items.
  * - Scans src/components/blog/*.tsx (excluding *.stories.tsx) as registry:component items.
+ * - Scans src/hooks/*.{ts,tsx} as registry:hook items, and wires them into the
+ *   registryDependencies of any component that imports them via `@/hooks/*`.
  * - Adds the cn util, the dark-theme stylesheet, and the meta `gymnopedies` preset.
  *
  * Run with `npm run registry:build` to also produce public/r/*.json via the shadcn CLI.
@@ -41,6 +43,7 @@ type RegistryItem = {
 const ROOT = process.cwd()
 const UI_DIR = join(ROOT, "src", "components", "ui")
 const BLOG_DIR = join(ROOT, "src", "components", "blog")
+const HOOK_DIR = join(ROOT, "src", "hooks")
 
 // shadcn resolves bare registryDependencies names ("button", "utils", …)
 // against its own default registry. Cross-references within a custom
@@ -86,6 +89,32 @@ const extractExternalDeps = (filePath: string): string[] => {
     deps.add(pkgName)
   }
   return [...deps].sort()
+}
+
+// `.ts` / `.tsx` files under src/hooks, excluding stories.
+const hookFiles = (dir: string) =>
+  readdirSync(dir)
+    .filter(
+      (f) =>
+        (f.endsWith(".ts") || f.endsWith(".tsx")) &&
+        !/\.stories\.tsx?$/.test(f),
+    )
+    .map((f) => ({ name: f.replace(/\.tsx?$/, ""), file: f }))
+    .sort((a, b) => a.name.localeCompare(b.name))
+
+const HOOK_IMPORT_RE =
+  /(?:^|\n)\s*import\s+(?:[^"';]*?\s+from\s+)?["']@\/hooks\/([^"'/]+)["']/g
+
+// Names of hooks a component pulls in via the `@/hooks/*` alias. These need
+// to ride along as registryDependencies, otherwise `shadcn add` copies the
+// component without the hook it imports.
+const extractHookDeps = (filePath: string): string[] => {
+  const src = readFileSync(filePath, "utf8")
+  const hooks = new Set<string>()
+  for (const match of src.matchAll(HOOK_IMPORT_RE)) {
+    hooks.add(match[1])
+  }
+  return [...hooks].sort()
 }
 
 const utilItem: RegistryItem = {
@@ -155,9 +184,23 @@ const themeItem: RegistryItem = {
   },
 }
 
+const hookItems: RegistryItem[] = hookFiles(HOOK_DIR).map(({ name, file }) => {
+  const filePath = join(HOOK_DIR, file)
+  const dependencies = extractExternalDeps(filePath)
+  return {
+    name,
+    type: "registry:hook",
+    title: toTitle(name),
+    description: `${toTitle(name)} — gymnopédies hook.`,
+    files: [{ path: `src/hooks/${file}`, type: "registry:hook" }],
+    ...(dependencies.length > 0 ? { dependencies } : {}),
+  }
+})
+
 const uiItems: RegistryItem[] = componentFiles(UI_DIR).map((name) => {
   const filePath = join(UI_DIR, `${name}.tsx`)
   const dependencies = extractExternalDeps(filePath)
+  const hookDeps = extractHookDeps(filePath)
   return {
     name,
     type: "registry:ui",
@@ -165,13 +208,14 @@ const uiItems: RegistryItem[] = componentFiles(UI_DIR).map((name) => {
     description: `${toTitle(name)} — gymnopédies-themed shadcn primitive.`,
     files: [{ path: `src/components/ui/${name}.tsx`, type: "registry:ui" }],
     ...(dependencies.length > 0 ? { dependencies } : {}),
-    registryDependencies: [ref("utils")],
+    registryDependencies: [ref("utils"), ...hookDeps.map(ref)],
   }
 })
 
 const blogItems: RegistryItem[] = componentFiles(BLOG_DIR).map((name) => {
   const filePath = join(BLOG_DIR, `${name}.tsx`)
   const dependencies = extractExternalDeps(filePath)
+  const hookDeps = extractHookDeps(filePath)
   return {
     name,
     type: "registry:component",
@@ -181,7 +225,7 @@ const blogItems: RegistryItem[] = componentFiles(BLOG_DIR).map((name) => {
       { path: `src/components/blog/${name}.tsx`, type: "registry:component" },
     ],
     ...(dependencies.length > 0 ? { dependencies } : {}),
-    registryDependencies: [ref("utils"), ref("theme")],
+    registryDependencies: [ref("utils"), ref("theme"), ...hookDeps.map(ref)],
   }
 })
 
@@ -196,6 +240,7 @@ const presetItem: RegistryItem = {
     ref("theme"),
     ...uiItems.map((i) => ref(i.name)),
     ...blogItems.map((i) => ref(i.name)),
+    ...hookItems.map((i) => ref(i.name)),
   ],
 }
 
@@ -203,7 +248,14 @@ const registry = {
   $schema: "https://ui.shadcn.com/schema/registry.json",
   name: "gymnopedies",
   homepage: "https://github.com/shoota/gymnopedies",
-  items: [utilItem, themeItem, ...uiItems, ...blogItems, presetItem],
+  items: [
+    utilItem,
+    themeItem,
+    ...uiItems,
+    ...blogItems,
+    ...hookItems,
+    presetItem,
+  ],
 }
 
 writeFileSync(
@@ -214,9 +266,10 @@ writeFileSync(
 const counts = {
   ui: uiItems.length,
   blog: blogItems.length,
+  hook: hookItems.length,
   total: registry.items.length,
 }
 
 console.log(
-  `Wrote registry.json with ${counts.total} items (${counts.ui} ui + ${counts.blog} blog + utils + theme + preset).`,
+  `Wrote registry.json with ${counts.total} items (${counts.ui} ui + ${counts.blog} blog + ${counts.hook} hook + utils + theme + preset).`,
 )


### PR DESCRIPTION
## Summary

`/tmp` での shadcn 検証中に見つかった **3 つ目の registry 不具合**の修正です。

`build-registry.ts` は `src/components/ui` と `src/components/blog` しかスキャンしておらず、`src/hooks/` を見ていませんでした。`sidebar.tsx` は `@/hooks/use-mobile` を import していますが `use-mobile.ts` が registry に一切含まれず、`sidebar` を入れた利用者のプロジェクトは必ず型エラーになります：

```
src/components/ui/sidebar.tsx(6,29): error TS2307: Cannot find module '@/hooks/use-mobile'
```

## 修正内容

- `build-registry.ts` で `src/hooks/*.{ts,tsx}` を `registry:hook` item としてスキャン
- 各コンポーネントの `@/hooks/*` import を検出し、その hook の URL を `registryDependencies` に追加
- `gymnopedies` preset にも hook item を含める
- `registry.json` / `public/r/*.json` 再生成（`use-mobile.json` 追加、`sidebar.json` が依存するように）

## 検証

`shadcn init -b base -t vite` のクリーンなプロジェクトで、修正版 registry（URL をローカルに書き換えて配信）から `sidebar` を再 install：

- `✔ Created 1 file: src/hooks/use-mobile.ts` — hook が同梱された
- `npm run build`（`tsc -b && vite build`）が **exit 0** で完走（修正前は `tsc -b` で失敗）

## バージョン

`package.json` は既に `1.1.2`（PR #227）。tag / Release 未作成なので bump 不要。README の v1.1.2 リリースノートに hook 修正を追記しました。**v1.1.2 = #228（URL 修正）+ 本 PR（hook 修正）** の一括リリースになります。

## Test plan

- [x] `npm run registry:build` で再生成、`use-mobile.json` 生成・`sidebar.json` の registryDependencies 更新を確認
- [x] `npm run typecheck` / `npm run lint`
- [x] クリーンな vite プロジェクトで `sidebar` install → `use-mobile.ts` 同梱 → `tsc -b` 通過
- [ ] マージ後、本番 registry で whole install を再確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)