### PR TITLE
docs: switch install commands to @gymnopedies namespace and cross-link sample blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,11 @@ Forms are intentionally out of scope — gymnopédies is a read-only design syst
 
 ## Quick start
 
-gymnopédies is distributed as a [shadcn registry](https://ui.shadcn.com/docs/registry):
-the CLI copies component **source** straight into your project. There is no
-runtime npm dependency on gymnopédies itself — you own the code once it lands.
+gymnopédies is distributed as a [shadcn registry](https://ui.shadcn.com/docs/registry)
+and listed in the official [shadcn registry directory](https://ui.shadcn.com/registry)
+as **`@gymnopedies`**. The CLI copies component **source** straight into your
+project — there is no runtime npm dependency on gymnopédies itself; you own
+the code once it lands.
 
 Requirements: a React project with **Tailwind CSS v4** and the `@/*` path alias.
 A fresh Vite app set up with shadcn works out of the box:
@@ -29,7 +31,7 @@ A fresh Vite app set up with shadcn works out of the box:
 npx shadcn@latest init -b base -t vite
 
 # 2. install the whole gymnopédies preset
-npx shadcn@latest add https://gymnopedies.shoota.work/r/gymnopedies.json
+npx shadcn@latest add @gymnopedies/gymnopedies
 ```
 
 The preset pulls in the theme tokens, every non-form shadcn primitive, the
@@ -40,9 +42,9 @@ dependencies (`@base-ui/react`, `class-variance-authority`, `lucide-react`,
 Prefer to cherry-pick? Add items one at a time:
 
 ```bash
-npx shadcn@latest add https://gymnopedies.shoota.work/r/theme.json
-npx shadcn@latest add https://gymnopedies.shoota.work/r/hero.json
-npx shadcn@latest add https://gymnopedies.shoota.work/r/article.json
+npx shadcn@latest add @gymnopedies/theme
+npx shadcn@latest add @gymnopedies/hero
+npx shadcn@latest add @gymnopedies/article
 ```
 
 Then compose a page — see the [sample blog](https://gymnopedies.shoota.work/examples/blog/)
@@ -158,7 +160,7 @@ There is no compatibility shim. If you are still on `gymnopedies@0.1.x` (Emotion
 
 1. Remove `gymnopedies` from `dependencies`.
 2. Install Tailwind v4 in your project: `npx shadcn@latest init`.
-3. Adopt the v1 components via `npx shadcn@latest add <url>`.
+3. Adopt the v1 components via `npx shadcn@latest add @gymnopedies/<name>`.
 4. Rewrite call sites — APIs are not source-compatible:
    - The legacy `Card` returns as `blog/Article` with the same Props.
    - `Picture` moved to a compound API (`Picture.Image` / `Picture.Caption`).

--- a/examples/blog/src/components/SiteHeader.tsx
+++ b/examples/blog/src/components/SiteHeader.tsx
@@ -2,11 +2,21 @@ import { HeaderNavigation } from "@/components/blog/header-navigation"
 import type { Route } from "@blog/router"
 import { navigate } from "@blog/router"
 
-type NavKey = "home" | "posts" | "about"
+type NavKey = "home" | "posts" | "storybook" | "about"
 
-const navItems: { key: NavKey; name: string; route: Route | null }[] = [
+const STORYBOOK_URL = "https://gymnopedies.shoota.work/"
+
+type NavItem = {
+  key: NavKey
+  name: string
+  route: Route | null
+  external?: string
+}
+
+const navItems: NavItem[] = [
   { key: "home", name: "Home", route: { name: "home" } },
   { key: "posts", name: "Articles", route: { name: "posts" } },
+  { key: "storybook", name: "Storybook", route: null, external: STORYBOOK_URL },
   { key: "about", name: "About", route: null },
 ]
 
@@ -21,11 +31,14 @@ export function SiteHeader({ active }: { active: NavKey }) {
           name: item.name,
           onClick: item.route
             ? () => navigate(item.route!)
-            : () => {
-                window.alert(
-                  "This is a gymnopédies sample blog — the 'About' page is left as an exercise to the reader.",
-                )
-              },
+            : item.external
+              ? () =>
+                  window.open(item.external, "_blank", "noopener,noreferrer")
+              : () => {
+                  window.alert(
+                    "This is a gymnopédies sample blog — the 'About' page is left as an exercise to the reader.",
+                  )
+                },
         }))}
       />
     </div>

--- a/src/welcome/Introduction.mdx
+++ b/src/welcome/Introduction.mdx
@@ -8,7 +8,9 @@ A **shadcn registry** of dark, serif, glow-leaning React components for
 long-form reading experiences — blogs, essays, archives, photo journals.
 
 > No npm publish. Source is copied straight into your project via the
-> `shadcn` CLI.
+> `shadcn` CLI. Listed in the
+> [official shadcn directory](https://ui.shadcn.com/registry) as
+> **`@gymnopedies`**.
 
 ---
 
@@ -20,23 +22,23 @@ long-form reading experiences — blogs, essays, archives, photo journals.
 ### 1. Install the whole preset (theme + every component)
 
 ```bash
-npx shadcn@latest add https://gymnopedies.shoota.work/r/gymnopedies.json
+npx shadcn@latest add @gymnopedies/gymnopedies
 ```
 
 ### 2. Or pick individual items
 
 ```bash
 # theme tokens (dark / serif / glow)
-npx shadcn@latest add https://gymnopedies.shoota.work/r/theme.json
+npx shadcn@latest add @gymnopedies/theme
 
 # blog-oriented primitives
-npx shadcn@latest add https://gymnopedies.shoota.work/r/article.json
-npx shadcn@latest add https://gymnopedies.shoota.work/r/hero.json
-npx shadcn@latest add https://gymnopedies.shoota.work/r/global-styles.json
+npx shadcn@latest add @gymnopedies/article
+npx shadcn@latest add @gymnopedies/hero
+npx shadcn@latest add @gymnopedies/global-styles
 
 # any non-form shadcn primitive (Base UI under the hood)
-npx shadcn@latest add https://gymnopedies.shoota.work/r/card.json
-npx shadcn@latest add https://gymnopedies.shoota.work/r/dialog.json
+npx shadcn@latest add @gymnopedies/card
+npx shadcn@latest add @gymnopedies/dialog
 ```
 
 ---
@@ -107,6 +109,8 @@ so Markdown-rendered blog HTML stays themed without becoming React.
 ## Links
 
 - 🌐 **Live registry & this Storybook** — [gymnopedies.shoota.work](https://gymnopedies.shoota.work/)
+- 📖 **Sample blog (Quiet Pages)** — [gymnopedies.shoota.work/examples/blog/](https://gymnopedies.shoota.work/examples/blog/)
+- 🗂️ **shadcn directory** — [@gymnopedies on ui.shadcn.com/registry](https://ui.shadcn.com/registry)
 - 📦 **GitHub** — [shoota/gymnopedies](https://github.com/shoota/gymnopedies)
 - 🧪 **Chromatic visual history** — [build #7 baseline](https://www.chromatic.com/build?appId=662d32d94288f3b7f7ceecf5&number=7)
 - 📝 **Release notes** — see [v1.0.0](https://github.com/shoota/gymnopedies/releases/tag/v1.0.0)


### PR DESCRIPTION
## Summary

shadcn 公式 directory ([ui.shadcn.com/registry](https://ui.shadcn.com/registry)) に `@gymnopedies` として登録された (shadcn-ui/ui#10728) ことで、CLI で **`npx shadcn@latest add @gymnopedies/<name>`** という namespace 形式の短縮インストールが使えるようになりました。これに合わせてドキュメントを更新します。

## 変更内容

### `README.md`
- Quick start の install コマンドを `@gymnopedies/<name>` 形式に統一
- 「official shadcn registry directory に listed」の一文を追加
- Migration 節の `<url>` プレースホルダを `@gymnopedies/<name>` に更新

### `src/welcome/Introduction.mdx` (Storybook intro)
- Install コマンドを namespace 形式に統一
- Links 節に以下を追加:
  - 📖 **Sample blog (Quiet Pages)** へのリンク
  - 🗂️ **shadcn directory** (@gymnopedies on ui.shadcn.com/registry) へのリンク
- 冒頭の引用ブロックに directory listing への言及を追加

### `examples/blog/src/components/SiteHeader.tsx`
- ナビゲーション項目に **Storybook** 外部リンクを追加 (Home / Articles / **Storybook** / About)
- `NavItem` 型を拡張し `external?: string` を追加。`window.open(url, "_blank", "noopener,noreferrer")` で別タブ遷移

## 検証

- [x] `npm run typecheck` パス
- [x] `npm run lint` パス
- [ ] ローカルで `npm run dev:examples` を起動して Storybook リンクの動作を目視確認 (推奨)

## 補足

URL 直指定 (`https://gymnopedies.shoota.work/r/<name>.json`) は今まで通り使用可能ですが、ドキュメント上の例は namespace 形式に統一しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)