### PR TITLE
docs: pin preset in quick-start init to skip interactive prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,14 @@ as **`@gymnopedies`**. The CLI copies component **source** straight into your
 project — there is no runtime npm dependency on gymnopédies itself; you own
 the code once it lands.
 
-Requirements: a React project with **Tailwind CSS v4** and the `@/*` path alias.
+Requirements: a React 18+ project with **Tailwind CSS v4** and the `@/*` tsconfig path alias.
 A fresh Vite app set up with shadcn works out of the box:
 
 ```bash
 # 1. scaffold a shadcn-ready Vite app (skip if you already have a project)
-npx shadcn@latest init -b base -t vite
+#    -p nova picks a base preset to skip the interactive prompt;
+#    gymnopédies overrides the theme either way.
+npx shadcn@latest init -b base -t vite -p nova
 
 # 2. install the whole gymnopédies preset
 npx shadcn@latest add @gymnopedies/gymnopedies


### PR DESCRIPTION
## Summary

- shadcn CLI v4.8.3 makes preset selection a required interactive prompt; the documented `init -b base -t vite` halts on a fresh run. Add `-p nova` so the example completes non-interactively (any preset works — gymnopédies overrides the theme either way).
- Align the README prerequisites wording with `src/welcome/Introduction.mdx` (React 18+ / `@/*` tsconfig path alias).

Verified locally by running the full quick-start (Vite + Tailwind v4 + alias + `init` + `add @gymnopedies/gymnopedies`) against the public registry — all items resolve via the `@gymnopedies` namespace from the shadcn directory and `tsc --noEmit` passes on generated files.

## Test plan

- [x] `npx shadcn@latest init -b base -t vite -p nova -y` completes without interactive prompts on a fresh Vite + React-TS + Tailwind v4 project
- [x] `npx shadcn@latest add @gymnopedies/theme` resolves the namespace and writes `globals.css`
- [x] `npx shadcn@latest add @gymnopedies/gymnopedies` installs the full preset (37 files) plus npm deps
- [x] `tsc --noEmit` on the generated source passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)