### PR TITLE
chore(release): bump to v1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to gymnopédies are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/), and the project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## [1.1.3] — 2026-06-02
+
+### Added
+
+- **`author` and `categories` metadata on every registry item.** The shadcn
+  `registry-item` schema recommends both fields; they are now emitted for all
+  items, in preparation for listing gymnopédies on the public shadcn registry
+  directory (<https://ui.shadcn.com/registry>).
+
+### Changed
+
+- **`homepage` now points at the hosting domain.** `registry.json` and
+  `package.json` advertised the GitHub repository URL; both now use
+  <https://gymnopedies.shoota.work>, matching where the registry is served.
+- Bumped `tailwind-merge` to `^3.6.0`.
+- Install commands in the README now use the `@gymnopedies` namespace and the
+  quick-start `init` pins the `base` preset to skip the interactive prompt.
+
 ## [1.1.2] — 2026-05-14
 
 ### Fixed
@@ -72,6 +90,7 @@ into consumer projects.
   `src/components/blog`).
 - Ported the legacy bespoke components to Tailwind compound APIs.
 
+[1.1.3]: https://github.com/shoota/gymnopedies/compare/v1.1.2...v1.1.3
 [1.1.2]: https://github.com/shoota/gymnopedies/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/shoota/gymnopedies/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/shoota/gymnopedies/compare/v1.0.0...v1.1.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gymnopedies",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gymnopedies",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "MIT",
       "dependencies": {
         "@base-ui/react": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gymnopedies",
   "private": false,
-  "version": "1.1.2",
+  "version": "1.1.3",
   "type": "module",
   "author": {
     "name": "shoota"


### PR DESCRIPTION
## What

`1.1.2` → `1.1.3` のパッチリリース。`v1.1.2` 以降にマージ済みの registry 周りの変更をリリースに乗せる。

## Changes

- `package.json` / `package-lock.json` のバージョンを `1.1.3` に bump
- `CHANGELOG.md` に `[1.1.3]` セクションを追加

## Included since v1.1.2

### Added
- 全 registry item に `author` / `categories` メタデータを付与（shadcn 公式 directory 登録準備）

### Changed
- `registry.json` / `package.json` の `homepage` を配信ドメイン `https://gymnopedies.shoota.work` に統一
- `tailwind-merge` を `^3.6.0` に更新
- README のインストールコマンドを `@gymnopedies` namespace に変更、quick-start の `init` で `base` preset を固定

## Release steps (after merge)

1. `git tag v1.1.3 && git push origin v1.1.3`
2. GitHub Releases で `v1.1.3` を publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)
